### PR TITLE
Change broken overleaf link

### DIFF
--- a/mikiel-gica.md
+++ b/mikiel-gica.md
@@ -21,7 +21,7 @@ I am interested in adaptive meshing methods for high speed CFD problems.
 ## Project
 *Project Repository:* https://github.com/SCOREC/adaptiveController
 
-*Project Proposal:* https://www.overleaf.com/project/679652e8ef521259e76bd8f6
+*Project Proposal:* https://github.com/gicamikiel/Computing-at-Scale/releases/tag/term_project_proposal
 
 *Project Progress Report:*
 


### PR DESCRIPTION
The overleaf link I wrote in the the term project submissions section got broken somehow. I uploaded the PDF to GitHub as a release then linked it here.